### PR TITLE
Add GraphQL Federation support with required types and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,88 @@ $ graphql-schema-subgraph-migrator -config example/config.json -schema example/e
 extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key","@external","@shareable","@provides","@requires"])
 type User @key(fields: "id", resolvable: true) {
         id: ID
-        name: String @external
+        name: String
         email: String
 }
-type Post @key(fields: "id title", resolvable: true) {
+type Post @key(fields: "id", resolvable: true) {
         id: ID
         title: String
         body: String
-        author: User @external
+        author: User
 }
+scalar _Any
+scalar FieldSet
+scalar link__Import
+scalar federation__ContextFieldValue
+scalar federation__Scope
+scalar federation__Policy
+enum link__Purpose {
+        """
+        SECURITY features provide metadata necessary to securely resolve fields.
+        """
+        SECURITY
+        """
+        EXECUTION features provide metadata necessary for operation execution.
+        """
+        EXECUTION
+}
+type _Service {
+        sdl: String!
+}
+type Query {
+        _entities(representations: [_Any!]!): [_Entity]!
+        _service: _Service!
+}
+union _Entity = User | Post
+```
 
+### intermediate
+
+```bash
+$ graphql-schema-subgraph-migrator -config example/config.json -schema example/intermediate.graphqls
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key","@external","@shareable","@provides","@requires"])
+type User @key(fields: "id", resolvable: true) {
+        id: ID
+        name: String
+        email: String
+}
+type Post @key(fields: "id", resolvable: true) {
+        id: ID
+        title: String
+        body: String
+        author: User
+}
+type Comment {
+        post: Post
+        author: User
+        body: String
+}
+type Query {
+        getUser(userId: ID): User
+        _entities(representations: [_Any!]!): [_Entity]!
+        _service: _Service!
+}
+union _Entity = User | Post
+scalar _Any
+scalar FieldSet
+scalar link__Import
+scalar federation__ContextFieldValue
+scalar federation__Scope
+scalar federation__Policy
+enum link__Purpose {
+        """
+        SECURITY features provide metadata necessary to securely resolve fields.
+        """
+        SECURITY
+        """
+        EXECUTION features provide metadata necessary for operation execution.
+        """
+        EXECUTION
+}
+type _Service {
+        sdl: String!
+}
+union _Entity = User | Post
 ```
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ graphql-schema-subgraph-migrator version dev (none) built at unknown
 ### example
 
 ```bash
-$ graphql-schema-subgraph-migrator -config example/config.json -schema example/example.graphqls
+$ graphql-schema-subgraph-migrator -config example/config.json -schema example/example.graphqls 
 extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key","@external","@shareable","@provides","@requires"])
 type User @key(fields: "id", resolvable: true) {
         id: ID
-        name: String
+        name: String @external
         email: String
 }
-type Post @key(fields: "id", resolvable: true) {
+type Post @key(fields: "id title", resolvable: true) {
         id: ID
         title: String
         body: String
-        author: User
+        author: User @external
 }
 scalar _Any
 scalar FieldSet

--- a/example/intermediate.graphqls
+++ b/example/intermediate.graphqls
@@ -1,0 +1,24 @@
+type User {
+    id: ID
+    name: String
+    email: String
+}
+
+type Post {
+    id: ID
+    title: String
+    body: String
+    author: User
+}
+
+type Comment {
+    post: Post
+    author: User
+    body: String
+}
+
+type Query {
+    getUser(userId: ID): User
+}
+
+union _Entity = User | Post


### PR DESCRIPTION
Implement GraphQL Federation by adding necessary scalar and enum types, along with the `_entities` and `_service` fields in the Query type. Introduce User, Post, and Comment types to enhance data fetching capabilities.